### PR TITLE
Support clusters with nondefault cluster DNS names

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Unlike the default `configurable-http-proxy` that ships with Jupyterhub, the tra
 
 The proxy can be deployed to a Kubernetes namespace running Jupyterhub by applying the following config:
 Change SUB_DOMAIN_HOST to a value to a hostname where jupyterhub is hosted. The ISTIO_GATEWAY value should be set to
-the gateway which handles traffic for jupyterhub.
+the gateway which handles traffic for jupyterhub. If your cluster has a non-default domain, you can specify that with CLUSTER_DOMAIN
 
 ```yaml
 apiVersion: apps/v1
@@ -83,6 +83,8 @@ spec:
               value: jupyterhub
             - name: WAIT_FOR_WARMUP
               value: "true"
+            - name: CLUSTER_DOMAIN
+              value: "cluster.local"
           image: splunk/jupyterhub-istio-proxy:0.0.2
           imagePullPolicy: IfNotPresent
           name: proxy

--- a/main.go
+++ b/main.go
@@ -35,6 +35,7 @@ var gateway string
 var namespace string
 var waitForWarmup bool
 var vsNamePrefix string
+var clusterDomain string
 
 const (
 	gatewayEnvKey               = "ISTIO_GATEWAY"
@@ -44,6 +45,8 @@ const (
 	waitForWarmupKey            = "WAIT_FOR_WARMUP"
 	virtualServicePrefixKey     = "VIRTUAL_SERVICE_PREFIX"
 	virtualServicePrefixDefault = "jupyter"
+	clusterDomainEnvKey         = "CLUSTER_DOMAIN"
+	clusterDomainDefault        = "cluster.local"
 )
 
 func main() {
@@ -76,8 +79,11 @@ func main() {
 	if vsNamePrefix, ok = os.LookupEnv(virtualServicePrefixKey); !ok || vsNamePrefix == "" {
 		vsNamePrefix = virtualServicePrefixDefault
 	}
+	if clusterDomain, ok = os.LookupEnv(clusterDomainEnvKey); !ok || clusterDomain == "" {
+		clusterDomain = clusterDomainDefault
+	}
 	var ic proxy.Istioer
-	ic, err = proxy.NewIstioClient(namespace, gateway, subDomainHost, waitForWarmup, vsNamePrefix)
+	ic, err = proxy.NewIstioClient(namespace, gateway, subDomainHost, waitForWarmup, vsNamePrefix, clusterDomain)
 	if err != nil {
 		log.Fatalf("failed to create istio client: %s\n", err)
 	}

--- a/proxy/create.go
+++ b/proxy/create.go
@@ -43,7 +43,7 @@ func (i *IstioClient) createVirtualService(r route) error {
 		return err
 	}
 	destinationHost, destinationPort := r.splitTarget()
-	destinationHost = fmt.Sprintf("%s.%s.svc.cluster.local", destinationHost, i.namespace)
+	destinationHost = fmt.Sprintf("%s.%s.svc.%s", destinationHost, i.namespace, i.clusterDomain)
 	vsName := i.virtualServiceNameWithPrefix(r.RouteSpec)
 	vs := virtualService(vsName, i.gateway, i.host, destinationHost, destinationPort, r.RouteSpec, annotations)
 

--- a/proxy/istio.go
+++ b/proxy/istio.go
@@ -39,10 +39,11 @@ type IstioClient struct {
 	namespace     string
 	waitForWarmup bool
 	vsNamePrefix  string
+	clusterDomain string
 }
 
 // NewIstioClient returns a new IstioClient
-func NewIstioClient(namespace string, gateway string, host string, waitForWarmup bool, vsNamePrefix string) (*IstioClient, error) {
+func NewIstioClient(namespace string, gateway string, host string, waitForWarmup bool, vsNamePrefix string, clusterDomain string) (*IstioClient, error) {
 	// creates the in-cluster config
 	config, err := rest.InClusterConfig()
 	if err != nil {
@@ -52,7 +53,7 @@ func NewIstioClient(namespace string, gateway string, host string, waitForWarmup
 	if err != nil {
 		return nil, err
 	}
-	return &IstioClient{Clientset: ic, namespace: namespace, gateway: gateway, host: host, waitForWarmup: waitForWarmup, vsNamePrefix: vsNamePrefix}, nil
+	return &IstioClient{Clientset: ic, namespace: namespace, gateway: gateway, host: host, waitForWarmup: waitForWarmup, vsNamePrefix: vsNamePrefix, clusterDomain: clusterDomain}, nil
 }
 func (c IstioClient) virtualServiceAnnotationNameWithPrefix() string {
 	return fmt.Sprintf("%s.splunk.io/proxy-data", c.virtualServicePrefix())


### PR DESCRIPTION
@harsimranmaan First off, thanks for this project and for writing it up, it saved me a lot of work.

This is a small change to remove the hardcoded `cluster.local` cluster domain name - if a cluster has a non-default domain name, then `jupyterhub-istio-proxy` generates incorrect proxy configs that do not resolve, because it hardcodes the wrong cluster domain name.

I added an option to specify a non-default cluster domain name as an env var.

It's possible there is a more elegant way to fetch this from the kube API or the cluster itself, but this is what I'm starting with.

Let me know if it looks good to you or if you know of a better approach, thanks!

(Didn't add any tests since it's such a small change there's not much to test)