### PR TITLE
36: Add ability to reach /ping anonymously

### DIFF
--- a/proxy/http.go
+++ b/proxy/http.go
@@ -77,6 +77,12 @@ func RegisterRoutes(r *gin.Engine, ic Istioer, apiToken string) {
 
 func authorizedWithToken(apiToken string) gin.HandlerFunc {
 	return func(c *gin.Context) {
+		// Ignore /ping handler
+		if c.Request.URL.Path == "/ping" {
+			c.Next()
+			return
+		}
+
 		reqToken := c.Request.Header.Get("Authorization")
 		// Not bearer :o
 		bearerSplit := strings.Split(reqToken, "token ")

--- a/proxy/http.go
+++ b/proxy/http.go
@@ -26,13 +26,13 @@ import (
 
 // RegisterRoutes bootstraps http routes
 func RegisterRoutes(r *gin.Engine, ic Istioer, apiToken string) {
-	authorized := r.Group("/")
-	authorized.Use(authorizedWithToken(apiToken))
-	authorized.GET("/ping", func(c *gin.Context) {
+	r.GET("/ping", func(c *gin.Context) {
 		c.JSON(200, gin.H{
 			"message": "pong",
 		})
 	})
+
+	authorized := r.Group("/", authorizedWithToken(apiToken))
 	authorized.GET("/api/routes", func(c *gin.Context) {
 		var routes, err = ic.listRegisteredRoutes()
 		if err != nil {
@@ -77,12 +77,6 @@ func RegisterRoutes(r *gin.Engine, ic Istioer, apiToken string) {
 
 func authorizedWithToken(apiToken string) gin.HandlerFunc {
 	return func(c *gin.Context) {
-		// Ignore /ping handler
-		if c.Request.URL.Path == "/ping" {
-			c.Next()
-			return
-		}
-
 		reqToken := c.Request.Header.Get("Authorization")
 		// Not bearer :o
 		bearerSplit := strings.Split(reqToken, "token ")

--- a/proxy/http_test.go
+++ b/proxy/http_test.go
@@ -31,15 +31,15 @@ const (
 	validAuthToken string = "authtoken"
 )
 
-func TestPingForbidden(t *testing.T) {
+func TestPingNotForbidden(t *testing.T) {
 	var tests = []struct {
 		useHeader       bool
 		authHeaderValue string
 		expectedStatus  int
 	}{
-		{false, "", http.StatusForbidden},
-		{true, "", http.StatusForbidden},
-		{true, "invalid", http.StatusForbidden},
+		{false, "", http.StatusOK},
+		{true, "", http.StatusOK},
+		{true, "invalid", http.StatusOK},
 		{true, validAuthToken, http.StatusOK},
 	}
 	gin.DefaultWriter = ioutil.Discard


### PR DESCRIPTION
This closes #36 

It ignores auth. step for `/ping` endpoint

It is needed in order to create K8S healthchecks without tokens hardcoded